### PR TITLE
Feature/extention

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 export default function Home() {
 
     const [fontsLoaded, setFontsLoaded] = useState(false);
-    const { searchName, inputText } = useSelector((state: any) => state.userReducer)
+    const { searchName, inputText } = useSelector((state: any) => state.userReducer);
     const dispatch = useDispatch();
 
     const loadFonts = async () => {

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -4,6 +4,7 @@ export const SET_INPUT_TEXT = 'SET_INPUT_TEXT';
 export const SET_SEARCH_NAME = 'SET_SEARCH_NAME';
 export const SET_DATA_ARRAY = 'SET_DATA_ARRAY';
 export const SET_ERROR = 'SET_ERROR';
+export const SET_FUZZY_SEARCH = 'SET_FUZZY_SEARCH';
 
 interface SetInputTextAction {
   type: typeof SET_INPUT_TEXT;
@@ -25,7 +26,12 @@ interface SetErrorAction {
   payload: boolean;
 }
 
-export type ActionTypes = SetInputTextAction | SetSearchNameAction | SetDataArrayAction | SetErrorAction;
+interface SetFuzzySearchAction {
+  type: typeof SET_FUZZY_SEARCH;
+  payload: string[];
+}
+
+export type ActionTypes = SetInputTextAction | SetSearchNameAction | SetDataArrayAction | SetErrorAction | SetFuzzySearchAction;
 
 export const setInputText = (text: string): SetInputTextAction => ({
   type: SET_INPUT_TEXT,
@@ -45,4 +51,9 @@ export const setDataArray = (dataArray: TableData[]): SetDataArrayAction => ({
 export const setError = (error: boolean): SetErrorAction => ({
   type: SET_ERROR,
   payload: error,
+});
+
+export const setFuzzySearch = (name: string[]): SetFuzzySearchAction => ({
+  type: SET_FUZZY_SEARCH,
+  payload: name,
 });

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,11 +1,12 @@
 import { TableData } from 'types';
-import { ActionTypes, SET_INPUT_TEXT, SET_SEARCH_NAME, SET_DATA_ARRAY, SET_ERROR } from './actions';
+import { ActionTypes, SET_INPUT_TEXT, SET_SEARCH_NAME, SET_DATA_ARRAY, SET_ERROR, SET_FUZZY_SEARCH } from './actions';
 
 export interface StateType {
   inputText: string;
   searchName: string;
   dataArray: TableData[];
   error: boolean;
+  fuzzySearch: string[]
 }
 
 const initialState: StateType = {
@@ -13,6 +14,7 @@ const initialState: StateType = {
   searchName: '',
   dataArray: [],
   error: false,
+  fuzzySearch: []
 };
 
 const userReducer = (state = initialState, action: ActionTypes): StateType => {
@@ -25,6 +27,8 @@ const userReducer = (state = initialState, action: ActionTypes): StateType => {
       return { ...state, dataArray: action.payload };
     case SET_ERROR:
       return { ...state, error: action.payload };
+      case SET_FUZZY_SEARCH:
+        return { ...state, fuzzySearch: action.payload };
     default:
       return state;
   }

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -4,7 +4,7 @@ import { ActionTypes, SET_INPUT_TEXT, SET_SEARCH_NAME, SET_DATA_ARRAY, SET_ERROR
 export interface StateType {
   inputText: string;
   searchName: string;
-  dataArray: TableData[]; // Assuming TableData type is defined somewhere
+  dataArray: TableData[];
   error: boolean;
 }
 

--- a/src/test/actions.test.ts
+++ b/src/test/actions.test.ts
@@ -1,5 +1,5 @@
 import { TableData } from 'types';
-import { setInputText, setSearchName, setDataArray, setError, SET_INPUT_TEXT, SET_SEARCH_NAME, SET_DATA_ARRAY, SET_ERROR } from '../redux/actions';
+import { setInputText, setSearchName, setDataArray, setError, SET_INPUT_TEXT, SET_SEARCH_NAME, SET_DATA_ARRAY, SET_ERROR, SET_FUZZY_SEARCH, setFuzzySearch } from '../redux/actions';
 
 describe('Action Creators', () => {
   it('should create an action to set input text', () => {
@@ -36,6 +36,15 @@ describe('Action Creators', () => {
       payload: err,
     };
     expect(setError(err)).toEqual(expectedAction);
+  });
+
+  it('should create an action to set fuzzy search array', () => {
+    const array: string[] = ['Bo', 'Bob Burger'];
+    const expectedAction = {
+      type: SET_FUZZY_SEARCH,
+      payload: array,
+    };
+    expect(setFuzzySearch(array)).toEqual(expectedAction);
   });
 
 });

--- a/src/test/testData.ts
+++ b/src/test/testData.ts
@@ -1,0 +1,111 @@
+export const testData = 
+{
+  "1" : {
+    "bananas" : 200,
+    "lastDayPlayed" : "2018-11-22",
+    "longestStreak" : 1,
+    "name" : "Harry Potter",
+    "stars" : 6,
+    "subscribed" : false,
+    "uid" : "1"
+  },
+  "2" : {
+    "bananas" : 100,
+    "lastDayPlayed" : "2017-11-01",
+    "longestStreak" : 0,
+    "name" : "Ron Weasly",
+    "stars" : 4,
+    "subscribed" : false,
+    "uid" : "2"
+  },
+  "3" : {
+    "bananas" : 300,
+    "lastDayPlayed" : "2018-10-17",
+    "longestStreak" : 1,
+    "name" : "Hermione Granger",
+    "stars" : 4,
+    "subscribed" : false,
+    "uid" : "3"
+  },
+  "4" : {
+    "bananas" : 0,
+    "lastDayPlayed" : "2017-11-01",
+    "longestStreak" : 0,
+    "name" : "Yo Yo Chou",
+    "stars" : 4,
+    "subscribed" : false,
+    "uid" : "4"
+  },
+  "5" : {
+    "bananas" : 0,
+    "lastDayPlayed" : "2017-11-01",
+    "longestStreak" : 0,
+    "name" : "Toke Chen",
+    "stars" : 4,
+    "subscribed" : false,
+    "uid" : "5"
+  },
+  "6" : {
+    "bananas" : 20,
+    "lastDayPlayed" : "2017-11-01",
+    "longestStreak" : 0,
+    "name" : "Ryan",
+    "stars" : 5,
+    "subscribed" : false,
+    "uid" : "6"
+  },
+  "7" : {
+    "bananas" : 30,
+    "lastDayPlayed" : "2018-08-04",
+    "longestStreak" : 1,
+    "name" : "Amy",
+    "stars" : 9,
+    "subscribed" : false,
+    "uid" : "7"
+  },
+  "8" : {
+    "bananas" : 40,
+    "lastDayPlayed" : "2018-12-10",
+    "longestStreak" : 2,
+    "name" : "Mark Wong",
+    "stars" : 7,
+    "subscribed" : false,
+    "uid" : "8"
+  },
+  "9" : {
+    "bananas" : 50,
+    "lastDayPlayed" : "2018-06-17",
+    "longestStreak" : 1,
+    "name" : "Happy",
+    "stars" : 5,
+    "subscribed" : false,
+    "uid" : "9"
+  },
+  "10" : {
+    "bananas" : 60,
+    "lastDayPlayed" : "2017-11-01",
+    "longestStreak" : 0,
+    "name" : "Bob Burgers",
+    "stars" : 5,
+    "subscribed" : false,
+    "uid" : "10"
+  },
+  "12" : {
+    "bananas" : 80,
+    "lastDayPlayed" : "2019-01-24",
+    "longestStreak" : 1,
+    "name" : "Bo",
+    "stars" : 5,
+    "subscribed" : false,
+    "uid" : "12"
+  },
+  "11" : {
+    "bananas" : 90,
+    "lastDayPlayed" : "2019-01-24",
+    "longestStreak" : 1,
+    "name" : "",
+    "stars" : 5,
+    "subscribed" : false,
+    "uid" : "11"
+  }
+}

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { findName, sortArray, findTopTen, sortByBananas, sortAlphabetically, sortData, topTenData, addToLast } from "../utils";
+import { findName, sortArray, findTopTen, sortByBananas, sortAlphabetically, sortData, topTenData, addToLast, searchNames } from "../utils";
 import { testData } from './testData';
 
 describe('Utils Functions', () => {
@@ -108,6 +108,16 @@ describe('Utils Functions', () => {
             expect(addToLast(searchName, testData, sortedArray, topTen)[9][0]).toEqual(searchName);
             expect(addToLast(searchName, testData, sortedArray, topTen).length).toEqual(10);
         });
-
     });
+
+    describe('searchNames', () => {
+        it('should return an array of names matching the entered text', () => {
+            const searchedText = 'bo';
+            const searchedText2 = 'BO';
+            const expectedResult = ['Bob Burgers', 'Bo'];
+
+            expect(searchNames(testData, searchedText)).toEqual(expectedResult);
+            expect(searchNames(testData, searchedText2)).toEqual(expectedResult);
+        });
+    })
 })

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,0 +1,113 @@
+import { findName, sortArray, findTopTen, sortByBananas, sortAlphabetically, sortData, topTenData, addToLast } from "../utils";
+import { testData } from './testData';
+
+describe('Utils Functions', () => {
+
+    describe('findName' , () => {
+        it('should find the data with the matching name', () => {
+            const searchName: string = 'Harry Potter';
+            const expectedResult = [{
+                "bananas" : 200,
+                "lastDayPlayed" : "2018-11-22",
+                "longestStreak" : 1,
+                "name" : "Harry Potter",
+                "stars" : 6,
+                "subscribed" : false,
+                "uid" : "1"
+              }];
+            expect(findName(searchName, testData)).toEqual(expectedResult);
+        });
+    
+        it('should return an empty array if no match watching name is found', () => {
+            const searchName: string = 'Luna Lovegood';
+            const expectedResult: any[] = [];
+            expect(findName(searchName, testData)).toEqual(expectedResult);
+        });
+    });
+
+    describe('sortArray', () => {
+        it('should sort data in order of banana ranking', () => {
+            expect(sortArray(testData)[0].name).toEqual('Hermione Granger');
+            expect(sortArray(testData)[11].name).toEqual('Toke Chen');
+        });
+    });
+
+    describe('findTopTen', () => {
+        it('should return a an array with the top 10 users by rank', () => {
+            const topTenArray = findTopTen(sortArray(testData));
+            
+            expect(topTenArray.length).toEqual(10);
+            expect(topTenArray[0][0]).toEqual('Hermione Granger');
+        });
+    });
+
+    describe('sortBananas', () => {
+        it('should sort data by number of bananas and return all data', () => {
+            const formattedDataArray = sortArray(testData);
+
+            expect(sortByBananas(formattedDataArray).length).toEqual(12);
+            expect(sortByBananas(formattedDataArray)[11].name).toEqual('Toke Chen');
+        });
+    });
+   
+    describe('sortAlphebetically', () => {
+        it('should sort data by name alphabetically and return all data', () => {
+            const formattedDataArray = sortArray(testData);
+
+            expect(sortAlphabetically(formattedDataArray)[0].name).toEqual('');
+            expect(sortAlphabetically(formattedDataArray)[11].name).toEqual('Yo Yo Chou');
+        });
+    });
+
+    describe('sortData', () => {
+        it('should return data according to rank', () => {
+            const type = 'sortedArray';
+
+            expect(sortData(testData, type)[0][0]).toEqual('Hermione Granger');
+            expect(sortData(testData, type)[10][0]).toEqual('Toke Chen');
+        });
+
+        it('should return data in alphabetical order, without empty string names', () => {
+            const type = 'alphabeticalOrder';
+
+            expect(sortData(testData, type)[0][0]).toEqual('Amy');
+            expect(sortData(testData, type)[10][0]).toEqual('Yo Yo Chou');
+        });
+
+
+        it('should return data by lowest ranked', () => {
+            const type = 'lowestRanked';
+
+            expect(sortData(testData, type)[0][0]).toEqual('Toke Chen');
+            expect(sortData(testData, type)[10][0]).toEqual('Hermione Granger');
+        });
+
+        it('should return data by lowest ranked, and sorted by alphebetical order for duplicate banana scores', () => {
+            const type = 'lowestRanked';
+
+            expect(sortData(testData, type)[1][0]).toEqual('Yo Yo Chou');
+            expect(sortData(testData, type)[0][0]).toEqual('Toke Chen');
+        });
+    });
+
+    describe('topTenData', () => {
+        it('should return an array with the top 10, if searched name is in top 10', () => {
+            const searchName = 'Bo';
+
+            expect(topTenData(testData, searchName).length).toEqual(10);
+            expect(topTenData(testData, searchName)[4][0]).toEqual(searchName);
+        });
+    })
+
+    describe('addToLast', () => {
+        it('should return an array with top 10 and searched name added to bottom, if searched name isnt in top 10', () => {
+            const searchName = 'Toke Chen';
+            const sortedArray = sortArray(testData);
+            const topTen = topTenData(testData, searchName);
+
+            expect(addToLast(searchName, testData, sortedArray, topTen)[9][0]).toEqual(searchName);
+            expect(addToLast(searchName, testData, sortedArray, topTen).length).toEqual(10);
+        });
+
+    });
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,55 +4,59 @@ export const findName = (searchName: string, data: DataSet) => {
     return Object.values(data).filter(user => user.name.toLowerCase() === searchName.toLowerCase());
 };
 
-const findTopTen = (data: UserType[]): TableData[] => {
+export const sortArray = (data: DataSet): UserType[] => {
+    return Object.values(data).sort((a: UserType, b: UserType) => b.bananas - a.bananas);
+}
+
+export const findTopTen = (data: UserType[]): TableData[] => {
     return data.slice(0, 10).map((user: UserType, index) => {
         return [user.name, index + 1, user.bananas];
     })
 }
 
-const sortByBananas = (data: UserType[]): UserType[] => {
+export const sortByBananas = (data: UserType[]): UserType[] => {
     return data.slice().sort((a: UserType, b: UserType) => b.bananas - a.bananas);
-  };
-  
-  const sortAlphabetically = (data: UserType[]): UserType[] => {
+};
+
+export const sortAlphabetically = (data: UserType[]): UserType[] => {
     return data.slice().sort((a: UserType, b: UserType) => {
-      const nameA = a.name.toLowerCase();
-      const nameB = b.name.toLowerCase();
-      return nameA.localeCompare(nameB);
-    });
-  };
-  
-  const sortByBananasAndName = (data: UserType[]): UserType[] => {
-    return data.slice().sort((a: UserType, b: UserType) => {
-      if (b.bananas !== a.bananas) {
-        return a.bananas - b.bananas;
-      } else {
         const nameA = a.name.toLowerCase();
         const nameB = b.name.toLowerCase();
         return nameA.localeCompare(nameB);
-      }
-    });
-  };
-  
-  export const sortData = (data: DataSet, type: string): TableData[] => {
-    const filteredData = Object.values(data).filter((user: UserType) => user.name.trim() !== "");
-  
-    const sortedArray = sortByBananas(filteredData);
-    const alphabeticalOrder = sortAlphabetically(filteredData);
-    const lowestRanked = sortByBananasAndName(filteredData);
-  
-    const options: Options = {
-      'sortedArray': sortedArray,
-      'alphabeticalOrder': alphabeticalOrder,
-      'lowestRanked': lowestRanked
-    };
-  
-    return options[type].map((user: UserType, index: number) => {
-      return [user.name, sortedArray.indexOf(user) + 1, user.bananas];
     });
 };
 
-const addToLast = (searchName: string, data: DataSet, sortedArray: UserType[], topTen: TableData[]): TableData[] => {
+export const sortByBananasAndName = (data: UserType[]): UserType[] => {
+    return data.slice().sort((a: UserType, b: UserType) => {
+        if (b.bananas !== a.bananas) {
+            return a.bananas - b.bananas;
+        } else {
+            const nameA = a.name.toLowerCase();
+            const nameB = b.name.toLowerCase();
+            return nameA.localeCompare(nameB);
+        }
+    });
+};
+
+export const sortData = (data: DataSet, type: string): TableData[] => {
+    const filteredData = Object.values(data).filter((user: UserType) => user.name.trim() !== "");
+
+    const sortedArray = sortByBananas(filteredData);
+    const alphabeticalOrder = sortAlphabetically(filteredData);
+    const lowestRanked = sortByBananasAndName(filteredData);
+
+    const options: Options = {
+        'sortedArray': sortedArray,
+        'alphabeticalOrder': alphabeticalOrder,
+        'lowestRanked': lowestRanked
+    };
+
+    return options[type].map((user: UserType, index: number) => {
+        return [user.name, sortedArray.indexOf(user) + 1, user.bananas];
+    });
+};
+
+export const addToLast = (searchName: string, data: DataSet, sortedArray: UserType[], topTen: TableData[]): TableData[] => {
 
     if (findName(searchName, data).length && findName(searchName, data)[0].name !== "") {
         const foundData: TableData = [findName(searchName, data)[0].name, sortedArray.indexOf(findName(searchName, data)[0]) + 1, findName(searchName, data)[0].bananas];
@@ -68,10 +72,10 @@ const addToLast = (searchName: string, data: DataSet, sortedArray: UserType[], t
 }
 
 export const topTenData = (data: DataSet, searchName: string): TableData[] => {
-    const sortedArray = Object.values(data).sort((a: UserType, b: UserType) => b.bananas - a.bananas);
+    const sortedArray = sortArray(data);
 
     const topTen = findTopTen(sortedArray);
-    
+
     return addToLast(searchName, data, sortedArray, topTen);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,3 +79,10 @@ export const topTenData = (data: DataSet, searchName: string): TableData[] => {
     return addToLast(searchName, data, sortedArray, topTen);
 }
 
+export const searchNames = (data: DataSet, searchText: string): string[] => {
+    const names: string[] = Object.values(data)
+      .filter((user) => user.name.toLowerCase().includes(searchText.toLowerCase()))
+      .map((user) => user.name);
+  
+    return names;
+};


### PR DESCRIPTION
### What I did:
- closes #7 and #9 
- Added filter buttons to filter by all score by rank, all scores in alphabetical order, and all scored by lowest ranked (and alphabetical order)
- Added a "fuzzy search feature" where users can type in a partial name, and will be given a list of names matched they can click on to search 

### Screenshots of UI:
<img width="331" alt="Screenshot 2023-11-27 at 7 02 00 PM" src="https://github.com/sakisandrac/react-native-scoreboard/assets/118419729/b18d855e-b8ec-448a-9dd8-b620e8da9f49">
<img width="328" alt="Screenshot 2023-11-29 at 12 51 20 PM" src="https://github.com/sakisandrac/react-native-scoreboard/assets/118419729/fe34ec66-0e99-4bb5-a946-40dba688c389">
